### PR TITLE
SET_LOWERHALF_FS_CONTEXT and RESTORE; workaround

### DIFF
--- a/contrib/mpi-proxy-split/.gitignore
+++ b/contrib/mpi-proxy-split/.gitignore
@@ -3,3 +3,6 @@ unit-test/*.exe
 proxy
 mpi-wrappers/*.c*
 mpi-wrappers/*.so*
+Makefile_config
+lower-half/lh_proxy
+test/ckpt_rank_0/

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_cart_wrappers.cpp
@@ -42,7 +42,7 @@ USER_DEFINED_WRAPPER(int, Cart_coords, (MPI_Comm) comm, (int) rank,
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Cart_coords)(realComm, rank, maxdims, coords);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -57,8 +57,8 @@ USER_DEFINED_WRAPPER(int, Cart_create, (MPI_Comm) old_comm, (int) ndims,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Cart_create)(realComm, ndims, dims,
                                   periods, reorder, comm_cart);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     MPI_Comm virtComm = ADD_NEW_COMM(*comm_cart);
     VirtualGlobalCommId::instance().createGlobalId(virtComm);
     *comm_cart = virtComm;
@@ -80,7 +80,7 @@ USER_DEFINED_WRAPPER(int, Cart_get, (MPI_Comm) comm, (int) maxdims,
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Cart_get)(realComm, maxdims, dims, periods, coords);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -94,8 +94,8 @@ USER_DEFINED_WRAPPER(int, Cart_map, (MPI_Comm) comm, (int) ndims,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   // FIXME: Need to virtualize this newrank??
   retval = NEXT_FUNC(Cart_map)(realComm, ndims, dims, periods, newrank);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     FncArg ds = CREATE_LOG_BUF(dims, ndims * sizeof(int));
     FncArg ps = CREATE_LOG_BUF(periods, ndims * sizeof(int));
     LOG_CALL(restoreCarts, Cart_map, comm, ndims, ds, ps, newrank);
@@ -112,7 +112,7 @@ USER_DEFINED_WRAPPER(int, Cart_rank, (MPI_Comm) comm,
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Cart_rank)(realComm, coords, rank);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -126,8 +126,8 @@ USER_DEFINED_WRAPPER(int, Cart_shift, (MPI_Comm) comm, (int) direction,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Cart_shift)(realComm, direction,
                                  disp, rank_source, rank_dest);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     LOG_CALL(restoreCarts, Cart_shift, comm, direction,
              disp, rank_source, rank_dest);
   }
@@ -144,8 +144,8 @@ USER_DEFINED_WRAPPER(int, Cart_sub, (MPI_Comm) comm,
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Cart_sub)(realComm, remain_dims, new_comm);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     int ndims = 0;
     MPI_Cartdim_get(comm, &ndims);
     MPI_Comm virtComm = ADD_NEW_COMM(*new_comm);
@@ -166,7 +166,7 @@ USER_DEFINED_WRAPPER(int, Cartdim_get, (MPI_Comm) comm, (int *) ndims)
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Cartdim_get)(realComm, ndims);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_collective_wrappers.cpp
@@ -83,7 +83,7 @@ USER_DEFINED_WRAPPER(int, Bcast,
     MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Bcast)(buffer, count, realType, root, realComm);
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   };
@@ -102,8 +102,8 @@ USER_DEFINED_WRAPPER(int, Ibcast,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Ibcast)(buffer, count, realType,
       root, realComm, request);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     MPI_Request virtRequest = ADD_NEW_REQUEST(*request);
     *request = virtRequest;
     LOG_CALL(restoreRequests, Ibcast, buffer, count, datatype,
@@ -125,7 +125,7 @@ USER_DEFINED_WRAPPER(int, Barrier, (MPI_Comm) comm)
     MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Barrier)(realComm);
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   };
@@ -142,7 +142,7 @@ USER_DEFINED_WRAPPER(int, Barrier, (MPI_Comm) comm)
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Barrier)(realComm);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
 
   dmtcp_mpi::TwoPhaseAlgo::instance().commit_finish();
@@ -158,8 +158,8 @@ USER_DEFINED_WRAPPER(int, Ibarrier, (MPI_Comm) comm, (MPI_Request *) request)
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Ibarrier)(realComm, request);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     MPI_Request virtRequest = ADD_NEW_REQUEST(*request);
     *request = virtRequest;
     LOG_CALL(restoreRequests, Ibarrier, comm, *request);
@@ -191,7 +191,7 @@ USER_DEFINED_WRAPPER(int, Allreduce,
       retval = NEXT_FUNC(Allreduce)(sendbuf, recvbuf, count,
                                     realType, realOp, realComm);
     }
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   };
@@ -212,7 +212,7 @@ USER_DEFINED_WRAPPER(int, Reduce,
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Reduce)(sendbuf, recvbuf, count,
                                realType, realOp, root, realComm);
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   };
@@ -232,8 +232,8 @@ USER_DEFINED_WRAPPER(int, Ireduce,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Ireduce)(sendbuf, recvbuf, count,
       realType, realOp, root, realComm, request);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     MPI_Request virtRequest = ADD_NEW_REQUEST(*request);
     *request = virtRequest;
     LOG_CALL(restoreRequests, Ireduce, sendbuf, recvbuf,
@@ -260,7 +260,7 @@ USER_DEFINED_WRAPPER(int, Reduce_scatter,
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Reduce_scatter)(sendbuf, recvbuf, recvcounts,
                                        realType, realOp, realComm);
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   };
@@ -280,7 +280,7 @@ MPI_Alltoall_internal(const void *sendbuf, int sendcount,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Alltoall)(sendbuf, sendcount, realSendType, recvbuf,
       recvcount, realRecvType, realComm);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -314,7 +314,7 @@ USER_DEFINED_WRAPPER(int, Alltoallv,
     retval = NEXT_FUNC(Alltoallv)(sendbuf, sendcounts, sdispls, realSendType,
                                   recvbuf, recvcounts, rdispls, realRecvType,
                                   realComm);
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   };
@@ -335,7 +335,7 @@ USER_DEFINED_WRAPPER(int, Gather, (const void *) sendbuf, (int) sendcount,
     retval = NEXT_FUNC(Gather)(sendbuf, sendcount, realSendType,
                                recvbuf, recvcount, realRecvType,
                                root, realComm);
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   };
@@ -357,7 +357,7 @@ USER_DEFINED_WRAPPER(int, Gatherv, (const void *) sendbuf, (int) sendcount,
     retval = NEXT_FUNC(Gatherv)(sendbuf, sendcount, realSendType,
                                 recvbuf, recvcounts, displs, realRecvType,
                                 root, realComm);
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   };
@@ -378,7 +378,7 @@ USER_DEFINED_WRAPPER(int, Scatter, (const void *) sendbuf, (int) sendcount,
     retval = NEXT_FUNC(Scatter)(sendbuf, sendcount, realSendType,
                                 recvbuf, recvcount, realRecvType,
                                 root, realComm);
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   };
@@ -400,7 +400,7 @@ USER_DEFINED_WRAPPER(int, Scatterv, (const void *) sendbuf,
     retval = NEXT_FUNC(Scatterv)(sendbuf, sendcounts, displs, realSendType,
                                  recvbuf, recvcount, realRecvType,
                                  root, realComm);
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   };
@@ -421,7 +421,7 @@ USER_DEFINED_WRAPPER(int, Allgather, (const void *) sendbuf, (int) sendcount,
     retval = NEXT_FUNC(Allgather)(sendbuf, sendcount, realSendType,
                                   recvbuf, recvcount, realRecvType,
                                   realComm);
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   };
@@ -443,7 +443,7 @@ USER_DEFINED_WRAPPER(int, Allgatherv, (const void *) sendbuf, (int) sendcount,
     retval = NEXT_FUNC(Allgatherv)(sendbuf, sendcount, realSendType,
                                    recvbuf, recvcounts, displs, realRecvType,
                                    realComm);
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   };
@@ -463,7 +463,7 @@ USER_DEFINED_WRAPPER(int, Scan, (const void *) sendbuf, (void *) recvbuf,
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Scan)(sendbuf, recvbuf, count,
                              realType, realOp, realComm);
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     DMTCP_PLUGIN_ENABLE_CKPT();
     return retval;
   };
@@ -480,8 +480,8 @@ USER_DEFINED_WRAPPER(int, Comm_split, (MPI_Comm) comm, (int) color, (int) key,
     MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Comm_split)(realComm, color, key, newcomm);
-    RETURN_TO_UPPER_HALF();
-    if (retval == MPI_SUCCESS && LOGGING()) {
+    RETURN_TO_UPPER_HALF(__func__);
+    if (retval == MPI_SUCCESS && LOGGING_MPI()) {
       MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
       VirtualGlobalCommId::instance().createGlobalId(virtComm);
       *newcomm = virtComm;
@@ -502,8 +502,8 @@ USER_DEFINED_WRAPPER(int, Comm_dup, (MPI_Comm) comm, (MPI_Comm *) newcomm)
     MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Comm_dup)(realComm, newcomm);
-    RETURN_TO_UPPER_HALF();
-    if (retval == MPI_SUCCESS && LOGGING()) {
+    RETURN_TO_UPPER_HALF(__func__);
+    if (retval == MPI_SUCCESS && LOGGING_MPI()) {
       MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
       VirtualGlobalCommId::instance().createGlobalId(virtComm);
       *newcomm = virtComm;

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_comm_wrappers.cpp
@@ -42,7 +42,7 @@ USER_DEFINED_WRAPPER(int, Comm_size, (MPI_Comm) comm, (int *) world_size)
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Comm_size)(realComm, world_size);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -54,7 +54,7 @@ USER_DEFINED_WRAPPER(int, Comm_rank, (MPI_Comm) comm, (int *) world_rank)
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Comm_rank)(realComm, world_rank);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -69,8 +69,8 @@ USER_DEFINED_WRAPPER(int, Comm_create, (MPI_Comm) comm, (MPI_Group) group,
     MPI_Group realGroup = VIRTUAL_TO_REAL_GROUP(group);
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     retval = NEXT_FUNC(Comm_create)(realComm, realGroup, newcomm);
-    RETURN_TO_UPPER_HALF();
-    if (retval == MPI_SUCCESS && LOGGING()) {
+    RETURN_TO_UPPER_HALF(__func__);
+    if (retval == MPI_SUCCESS && LOGGING_MPI()) {
       MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
       VirtualGlobalCommId::instance().createGlobalId(virtComm);
       *newcomm = virtComm;
@@ -90,7 +90,7 @@ USER_DEFINED_WRAPPER(int, Abort, (MPI_Comm) comm, (int) errorcode)
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Abort)(realComm, errorcode);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -104,7 +104,7 @@ USER_DEFINED_WRAPPER(int, Comm_compare,
   MPI_Comm realComm2 = VIRTUAL_TO_REAL_COMM(comm2);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Comm_compare)(realComm1, realComm2, result);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -116,7 +116,7 @@ MPI_Comm_free_internal(MPI_Comm *comm)
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(*comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Comm_free)(&realComm);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   return retval;
 }
 
@@ -124,7 +124,7 @@ USER_DEFINED_WRAPPER(int, Comm_free, (MPI_Comm *) comm)
 {
   DMTCP_PLUGIN_DISABLE_CKPT();
   int retval = MPI_Comm_free_internal(comm);
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     // NOTE: We cannot remove the old comm from the map, since
     // we'll need to replay this call to reconstruct any other comms that
     // might have been created using this comm.
@@ -146,8 +146,8 @@ USER_DEFINED_WRAPPER(int, Comm_set_errhandler,
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Comm_set_errhandler)(realComm, errhandler);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     LOG_CALL(restoreComms, Comm_set_errhandler, comm, errhandler);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
@@ -162,7 +162,7 @@ USER_DEFINED_WRAPPER(int, Topo_test,
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Topo_test)(realComm, status);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -175,8 +175,8 @@ USER_DEFINED_WRAPPER(int, Comm_split_type, (MPI_Comm) comm, (int) split_type,
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Comm_split_type)(realComm, split_type, key, inf, newcomm);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
     VirtualGlobalCommId::instance().createGlobalId(virtComm);
     *newcomm = virtComm;
@@ -197,7 +197,7 @@ USER_DEFINED_WRAPPER(int, Attr_get, (MPI_Comm) comm, (int) keyval,
   int realCommKeyval = VIRTUAL_TO_REAL_COMM_KEYVAL(keyval);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Attr_get)(realComm, realCommKeyval, attribute_val, flag);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -210,8 +210,8 @@ USER_DEFINED_WRAPPER(int, Attr_delete, (MPI_Comm) comm, (int) keyval)
   int realCommKeyval = VIRTUAL_TO_REAL_COMM_KEYVAL(keyval);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Attr_delete)(realComm, realCommKeyval);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     LOG_CALL(restoreComms, Attr_delete, comm, keyval);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
@@ -227,8 +227,8 @@ USER_DEFINED_WRAPPER(int, Attr_put, (MPI_Comm) comm,
   int realCommKeyval = VIRTUAL_TO_REAL_COMM_KEYVAL(keyval);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Attr_put)(realComm, realCommKeyval, attribute_val);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     LOG_CALL(restoreComms, Attr_put, comm, keyval, attribute_val);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
@@ -246,8 +246,8 @@ USER_DEFINED_WRAPPER(int, Comm_create_keyval,
   retval = NEXT_FUNC(Comm_create_keyval)(comm_copy_attr_fn,
                                          comm_delete_attr_fn,
                                          comm_keyval, extra_state);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     int virtCommKeyval = ADD_NEW_COMM_KEYVAL(*comm_keyval);
     *comm_keyval = virtCommKeyval;
     LOG_CALL(restoreComms, Comm_create_keyval,
@@ -265,8 +265,8 @@ USER_DEFINED_WRAPPER(int, Comm_free_keyval, (int *) comm_keyval)
   int realCommKeyval = VIRTUAL_TO_REAL_COMM_KEYVAL(*comm_keyval);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Comm_free_keyval)(&realCommKeyval);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     // NOTE: We cannot remove the old comm_keyval from the map, since
     // we'll need to replay this call to reconstruct any other comms that
     // might have been created using this comm_keyval.
@@ -286,7 +286,7 @@ MPI_Comm_create_group_internal(MPI_Comm comm, MPI_Group group, int tag,
   MPI_Group realGroup = VIRTUAL_TO_REAL_GROUP(group);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Comm_create_group)(realComm, realGroup, tag, newcomm);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -296,7 +296,7 @@ USER_DEFINED_WRAPPER(int, Comm_create_group, (MPI_Comm) comm,
 {
   std::function<int()> realBarrierCb = [=]() {
     int retval = MPI_Comm_create_group_internal(comm, group, tag, newcomm);
-    if (retval == MPI_SUCCESS && LOGGING()) {
+    if (retval == MPI_SUCCESS && LOGGING_MPI()) {
       MPI_Comm virtComm = ADD_NEW_COMM(*newcomm);
       VirtualGlobalCommId::instance().createGlobalId(virtComm);
       *newcomm = virtComm;

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_group_wrappers.cpp
@@ -40,8 +40,8 @@ USER_DEFINED_WRAPPER(int, Comm_group, (MPI_Comm) comm, (MPI_Group *) group)
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Comm_group)(realComm, group);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     MPI_Group virtGroup = ADD_NEW_GROUP(*group);
     *group = virtGroup;
     LOG_CALL(restoreGroups, Comm_group, comm, *group);
@@ -57,7 +57,7 @@ USER_DEFINED_WRAPPER(int, Group_size, (MPI_Group) group, (int *) size)
   MPI_Group realGroup = VIRTUAL_TO_REAL_GROUP(group);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Group_size)(realGroup, size);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -69,7 +69,7 @@ MPI_Group_free_internal(MPI_Group *group)
   MPI_Group realGroup = VIRTUAL_TO_REAL_GROUP(*group);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Group_free)(&realGroup);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   return retval;
 }
 
@@ -77,7 +77,7 @@ USER_DEFINED_WRAPPER(int, Group_free, (MPI_Group *) group)
 {
   DMTCP_PLUGIN_DISABLE_CKPT();
   int retval = MPI_Group_free_internal(group);
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     // NOTE: We cannot remove the old group, since we'll need
     // to replay this call to reconstruct any comms that might
     // have been created using this group.
@@ -99,7 +99,7 @@ USER_DEFINED_WRAPPER(int, Group_compare, (MPI_Group) group1,
   MPI_Group realGroup2 = VIRTUAL_TO_REAL_GROUP(group2);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Group_compare)(realGroup1, realGroup2, result);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -111,7 +111,7 @@ USER_DEFINED_WRAPPER(int, Group_rank, (MPI_Group) group, (int *) rank)
   MPI_Group realGroup = VIRTUAL_TO_REAL_GROUP(group);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Group_rank)(realGroup, rank);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -124,8 +124,8 @@ USER_DEFINED_WRAPPER(int, Group_incl, (MPI_Group) group, (int) n,
   MPI_Group realGroup = VIRTUAL_TO_REAL_GROUP(group);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Group_incl)(realGroup, n, ranks, newgroup);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     MPI_Group virtGroup = ADD_NEW_GROUP(*newgroup);
     *newgroup = virtGroup;
     FncArg rs = CREATE_LOG_BUF(ranks, n * sizeof(int));
@@ -146,7 +146,7 @@ USER_DEFINED_WRAPPER(int, Group_translate_ranks, (MPI_Group) group1,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Group_translate_ranks)(realGroup1, n, ranks1,
                                             realGroup2, ranks2);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_nextfunc.h
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_nextfunc.h
@@ -90,7 +90,7 @@
     DMTCP_PLUGIN_DISABLE_CKPT();                                               \
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);                                           \
     retval = NEXT_FUNC(name)(APPLY(STRIP, args));                              \
-    RETURN_TO_UPPER_HALF();                                                    \
+    RETURN_TO_UPPER_HALF(__func__);                                                    \
     DMTCP_PLUGIN_ENABLE_CKPT();                                                \
     return retval;                                                             \
   }

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_op_wrappers.cpp
@@ -41,8 +41,8 @@ USER_DEFINED_WRAPPER(int, Op_create,
   DMTCP_PLUGIN_DISABLE_CKPT();
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Op_create)(user_fn, commute, op);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     MPI_Op virtOp = ADD_NEW_OP(*op);
     *op = virtOp;
     LOG_CALL(restoreOps, Op_create, user_fn, commute, virtOp);
@@ -61,8 +61,8 @@ USER_DEFINED_WRAPPER(int, Op_free, (MPI_Op*) op)
   }
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Op_free)(&realOp);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     // NOTE: We cannot remove the old op, since we'll need
     // to replay this call to reconstruct any new op that might
     // have been created using this op.

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_p2p_wrappers.cpp
@@ -44,7 +44,7 @@ USER_DEFINED_WRAPPER(int, Send,
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Send)(buf, count, realType, dest, tag, realComm);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   updateLocalSends(count);
   DMTCP_PLUGIN_ENABLE_CKPT();
 #else
@@ -70,7 +70,7 @@ USER_DEFINED_WRAPPER(int, Isend,
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Isend)(buf, count, realType, dest, tag, realComm, request);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   if (retval == MPI_SUCCESS) {
     // Updating global counter of send bytes
     int size;
@@ -106,7 +106,7 @@ USER_DEFINED_WRAPPER(int, Rsend, (const void*) ibuf, (int) count,
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Rsend)(ibuf, count, realType, dest, tag, realComm);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   if (retval == MPI_SUCCESS) {
     // Updating global counter of send bytes
     int size;
@@ -136,7 +136,7 @@ USER_DEFINED_WRAPPER(int, Recv,
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Recv)(buf, count, realType, source, tag, realComm, status);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
 #else
   MPI_Request req;
   retval = MPI_Irecv(buf, count, datatype, source, tag, comm, &req);
@@ -179,7 +179,7 @@ USER_DEFINED_WRAPPER(int, Irecv,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Irecv)(buf, count, realType,
                             source, tag, realComm, request);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   if (retval == MPI_SUCCESS) {
     MPI_Request virtRequest = ADD_NEW_REQUEST(*request);
     *request = virtRequest;
@@ -208,7 +208,7 @@ USER_DEFINED_WRAPPER(int, Sendrecv, (const void *) sendbuf, (int) sendcount,
   retval = NEXT_FUNC(Sendrecv)(sendbuf, sendcount, sendtype, dest, sendtag,
                                recvbuf, recvcount, recvtype, source, recvtag,
                                realComm, status);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
 #else
   get_fortran_constants();
@@ -249,7 +249,7 @@ USER_DEFINED_WRAPPER(int, Sendrecv_replace, (void *) buf, (int) count,
   retval = NEXT_FUNC(Sendrecv_replace)(buf, count, realType,
                                        dest, sendtag, source, recvtag,
                                        realComm, status);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_request_wrappers.cpp
@@ -46,7 +46,7 @@ int MPI_Test_internal(MPI_Request *request, int *flag, MPI_Status *status,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   // MPI_Test can change the *request argument
   retval = NEXT_FUNC(Test)(&realRequest, flag, status);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   return retval;
 }
 
@@ -97,7 +97,7 @@ USER_DEFINED_WRAPPER(int, Test, (MPI_Request*) request,
     fflush(stdout);
 #endif
   }
-  if (retval == MPI_SUCCESS && *flag && LOGGING()) {
+  if (retval == MPI_SUCCESS && *flag && LOGGING_MPI()) {
     clearPendingRequestFromLog(*request);
     REMOVE_OLD_REQUEST(*request);
     *request = MPI_REQUEST_NULL;
@@ -143,7 +143,7 @@ USER_DEFINED_WRAPPER(int, Waitall, (int) count,
   DMTCP_PLUGIN_DISABLE_CKPT();
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Waitall)(count, array_of_requests, array_of_statuses);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   if (retval == MPI_SUCCESS) {
     for (int i = 0; i < count; i++) {
       clearPendingRequestFromLog(&array_of_requests[i]);
@@ -206,7 +206,7 @@ USER_DEFINED_WRAPPER(int, Wait, (MPI_Request*) request, (MPI_Status*) status)
       fflush(stdout);
 #endif
     }
-    if (flag && LOGGING()) {
+    if (flag && LOGGING_MPI()) {
       clearPendingRequestFromLog(*request);
       REMOVE_OLD_REQUEST(*request);
       *request = MPI_REQUEST_NULL;
@@ -237,7 +237,7 @@ USER_DEFINED_WRAPPER(int, Iprobe,
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Iprobe)(source, tag, realComm, flag, status);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -250,7 +250,7 @@ USER_DEFINED_WRAPPER(int, Request_get_status, (MPI_Request) request,
   MPI_Request realRequest = VIRTUAL_TO_REAL_REQUEST(request);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Request_get_status)(realRequest, flag, status);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_type_wrappers.cpp
@@ -39,7 +39,7 @@ USER_DEFINED_WRAPPER(int, Type_size, (MPI_Datatype) datatype, (int *) size)
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Type_size)(realType, size);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -51,8 +51,8 @@ USER_DEFINED_WRAPPER(int, Type_free, (MPI_Datatype *) type)
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(*type);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Type_free)(&realType);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     // NOTE: We cannot remove the old type, since we'll need
     // to replay this call to reconstruct any new type that might
     // have been created using this type.
@@ -71,11 +71,11 @@ USER_DEFINED_WRAPPER(int, Type_commit, (MPI_Datatype *) type)
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(*type);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Type_commit)(&realType);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   if (retval != MPI_SUCCESS) {
     realType = REMOVE_OLD_TYPE(*type);
   } else {
-    if (LOGGING()) {
+    if (LOGGING_MPI()) {
       LOG_CALL(restoreTypes, Type_commit, *type);
     }
   }
@@ -91,8 +91,8 @@ USER_DEFINED_WRAPPER(int, Type_contiguous, (int) count, (MPI_Datatype) oldtype,
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(oldtype);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Type_contiguous)(count, realType, newtype);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     MPI_Datatype virtType = ADD_NEW_TYPE(*newtype);
     *newtype = virtType;
     LOG_CALL(restoreTypes, Type_contiguous, count, oldtype, virtType);
@@ -111,8 +111,8 @@ USER_DEFINED_WRAPPER(int, Type_vector, (int) count, (int) blocklength,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Type_vector)(count, blocklength,
                                   stride, realType, newtype);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     MPI_Datatype virtType = ADD_NEW_TYPE(*newtype);
     *newtype = virtType;
     LOG_CALL(restoreTypes, Type_vector, count, blocklength,
@@ -144,8 +144,8 @@ USER_DEFINED_WRAPPER(int, Type_create_struct, (int) count,
   retval = NEXT_FUNC(Type_create_struct)(count, array_of_blocklengths,
                                    array_of_displacements,
                                    realTypes, newtype);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     MPI_Datatype virtType = ADD_NEW_TYPE(*newtype);
     *newtype = virtType;
     FncArg bs = CREATE_LOG_BUF(array_of_blocklengths, count * sizeof(int));
@@ -169,8 +169,8 @@ USER_DEFINED_WRAPPER(int, Type_indexed, (int) count,
   retval = NEXT_FUNC(Type_indexed)(count, array_of_blocklengths,
                                    array_of_displacements,
                                    realType, newtype);
-  RETURN_TO_UPPER_HALF();
-  if (retval == MPI_SUCCESS && LOGGING()) {
+  RETURN_TO_UPPER_HALF(__func__);
+  if (retval == MPI_SUCCESS && LOGGING_MPI()) {
     MPI_Datatype virtType = ADD_NEW_TYPE(*newtype);
     *newtype = virtType;
     FncArg bs = CREATE_LOG_BUF(array_of_blocklengths, count * sizeof(int));
@@ -191,7 +191,7 @@ USER_DEFINED_WRAPPER(int, Pack_size, (int) incount,
   MPI_Comm realComm = VIRTUAL_TO_REAL_COMM(comm);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Pack_size)(incount, realType, realComm, size);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }
@@ -207,7 +207,7 @@ USER_DEFINED_WRAPPER(int, Pack, (const void*) inbuf, (int) incount,
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Pack)(inbuf, incount, realType, outbuf,
                            outsize, position, realComm);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }

--- a/contrib/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
+++ b/contrib/mpi-proxy-split/mpi-wrappers/mpi_wrappers.cpp
@@ -38,9 +38,13 @@ DEFINE_FNC(int, Init_thread, (int *) argc, (char ***) argv,
 USER_DEFINED_WRAPPER(int, Init, (int *) argc, (char ***) argv) {
   int retval;
   DMTCP_PLUGIN_DISABLE_CKPT();
-  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
+ // JUMP_TO_LOWER_HALF(lh_info.fsaddr);
+do {
+	SwitchContext ctx((unsigned long)lh_info.fsaddr);
+
   retval = NEXT_FUNC(Init)(argc, argv);
-  RETURN_TO_UPPER_HALF();
+//   RETURN_TO_UPPER_HALF(__func__);
+} while(0); 
   initialize_drain_send_recv();
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
@@ -51,7 +55,7 @@ USER_DEFINED_WRAPPER(int, Init_thread, (int *) argc, (char ***) argv,
   DMTCP_PLUGIN_DISABLE_CKPT();
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Init_thread)(argc, argv, required, provided);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   initialize_drain_send_recv();
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
@@ -88,7 +92,7 @@ USER_DEFINED_WRAPPER(int, Get_count,
   MPI_Datatype realType = VIRTUAL_TO_REAL_TYPE(datatype);
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   retval = NEXT_FUNC(Get_count)(status, realType, count);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }

--- a/contrib/mpi-proxy-split/mpi_plugin.cpp
+++ b/contrib/mpi-proxy-split/mpi_plugin.cpp
@@ -92,6 +92,7 @@ dmtcp_skip_memory_region_ckpting(const ProcMapsArea *area)
   return 0;
 }
 
+/* Shall I just add TLS/TCB tracking here? */
 // Handler for SIGSEGV: forces the code into an infinite loop for attaching
 // GDB and debugging
 void

--- a/contrib/mpi-proxy-split/p2p_drain_send_recv.cpp
+++ b/contrib/mpi-proxy-split/p2p_drain_send_recv.cpp
@@ -305,6 +305,6 @@ localRankToGlobalRank(int localRank, MPI_Comm localComm)
                                    worldGroup, &worldRank); 
   NEXT_FUNC(Group_free)(&worldGroup);
   NEXT_FUNC(Group_free)(&localGroup);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   return worldRank;
 }

--- a/contrib/mpi-proxy-split/p2p_log_replay.cpp
+++ b/contrib/mpi-proxy-split/p2p_log_replay.cpp
@@ -198,7 +198,7 @@ replayMpiP2pOnRestart()
         NEXT_FUNC(Irecv)(call->recvbuf, call->count,
                          realType, call->remote_node,
                          call->tag, realComm, &realRequest);
-        RETURN_TO_UPPER_HALF();
+        RETURN_TO_UPPER_HALF(__func__);
         UPDATE_REQUEST_MAP(request, realRequest);
 #endif
         JASSERT(retval == MPI_SUCCESS).Text("Error while replaying recv");

--- a/contrib/mpi-proxy-split/record-replay.h
+++ b/contrib/mpi-proxy-split/record-replay.h
@@ -59,7 +59,7 @@
 // Returns true if we are currently replaying the MPI calls from the saved MPI
 // calls log; false, otherwise. Normally, this would be true while restoring
 // the MPI state at restart time. All other times, this would return false.
-#define LOGGING() \
+#define LOGGING_MPI() \
   dmtcp_mpi::MpiRecordReplay::instance().isReplayOn()
 
 // Calls the wrapper function corresponding to the given type 'type'. (The

--- a/contrib/mpi-proxy-split/split_process.cpp
+++ b/contrib/mpi-proxy-split/split_process.cpp
@@ -394,7 +394,10 @@ initializeLowerHalf()
     while (*evp++ != NULL);
     auxvec = (ElfW(auxv_t) *) evp;
   }
-  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
+//  JUMP_TO_LOWER_HALF(lh_info.fsaddr);
+  do {
+	  SwitchContext ctx((unsigned long)lh_info.fsaddr);
+
   // Clear any saved mappings in the lower half
   resetMmappedList_t resetMaps =
     (resetMmappedList_t)lh_info.resetMmappedListFptr;
@@ -419,7 +422,8 @@ initializeLowerHalf()
   // Restore the the auxiliary vector to correspond to the values of the upper
   // half.
   patchAuxv(auxvec, 0, 0, 0);
-  RETURN_TO_UPPER_HALF();
+//  RETURN_TO_UPPER_HALF(__func__);
+  } while(0);
   return ret;
 }
 

--- a/contrib/mpi-proxy-split/split_process.h
+++ b/contrib/mpi-proxy-split/split_process.h
@@ -22,6 +22,18 @@
 #ifndef _SPLIT_PROCESS_H
 #define _SPLIT_PROCESS_H
 
+#include <string.h>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <stdio.h>
+#include <vector>
+#include <signal.h>
+
+#include "jassert.h"
+#include "lower_half_api.h"
+
+#define SET_FS_CONTEXT
+
 // Helper class to save and restore context (in particular, the FS register),
 // when switching between the upper half and the lower half. In the current
 // design, the caller would generally be the upper half, trying to jump into
@@ -50,6 +62,9 @@ class SwitchContext
     ~SwitchContext();
 };
 
+#ifndef SET_FS_CONTEXT
+// ===================================================
+// FIXME: Fix this after the Linux 5.9 FSGSBASE patch
 // Helper macro to be used whenever making a jump from the upper half to
 // the lower half.
 #define JUMP_TO_LOWER_HALF(lhFs) \
@@ -58,9 +73,238 @@ class SwitchContext
 
 // Helper macro to be used whenever making a returning from the lower half to
 // the upper half.
-#define RETURN_TO_UPPER_HALF() \
+#define RETURN_TO_UPPER_HALF(__func__) \
   } while (0)
+#endif
+// ===================================================
+// Workaround for quickly changing the fs address
+static void *lh_fsaddr;
+static void *uh_fsaddr;
+static void *uh_fsaddr_tcb;
+static int fsaddr_initialized = 0;
+// in glibc 2.26 for x86_64
+// typedef struct
+// {
+//   void *tcb;            /* Pointer to the TCB.  Not necessarily the
+//                            thread descriptor used by libpthread.  */
+//   dtv_t *dtv;
+//   void *self;           /* Pointer to the thread descriptor.  */
+//   int multiple_threads;
+//   int gscope_flag;
+//   uintptr_t sysinfo;
+//   uintptr_t stack_guard;
+//   uintptr_t pointer_guard;
+//   unsigned long int vgetcpu_cache[2];
+// # ifndef __ASSUME_PRIVATE_FUTEX
+//   int private_futex;
+// # else
+//   int __glibc_reserved1;
+// # endif
+//   int __glibc_unused1;
+//   /* Reservation of some values for the TM ABI.  */
+//   void *__private_tm[4];
+//   /* GCC split stack support.  */
+//   void *__private_ss;
+//   long int __glibc_reserved2;
+//   /* Must be kept even if it is no longer used by glibc since programs,
+//      like AddressSanitizer, depend on the size of tcbhead_t.  */
+//   __128bits __glibc_unused2[8][4] __attribute__ ((aligned (32)));
+//
+//   void *__padding[8];
+// } tcbhead_t
+// TODO: make this configuable
+#ifndef LH_TLS_SIZE
+/* readelf -S lh_proxy
+ * [14] .tdata            PROGBITS         000000000e64d500  0044d500
+ *      000000000000002c  0000000000000000 WAT       0     0     8
+ * [15] .tbss             NOBITS           000000000e64d530  0044d52c
+ *      0000000000000462  0000000000000000 WAT       0     0     8
+ */
+#define LH_TLS_SIZE 0xcc0
+#endif
+constexpr static size_t TCB_HEADER_SIZE = 120; // offset of __glibc_reserved2
+constexpr static size_t PTHREAD_SIZE = 2304; // sizeof (struct pthread)
+constexpr static size_t PAGE_SIZE_4KB = 4096;
+constexpr static size_t PAGE_SIZE_4KB_ALIGN = ~(PAGE_SIZE_4KB - 1);
+static char fsaddr_buf[LH_TLS_SIZE + TCB_HEADER_SIZE];
+static char debug_buf[LH_TLS_SIZE + TCB_HEADER_SIZE];
+static std::vector<void *> changed_tls_tcb;
 
+#ifdef SET_FS_CONTEXT
+struct dtv_pointer
+{
+  void *val;                    /* Pointer to data, or TLS_DTV_UNALLOCATED.  */
+  void *to_free;                /* Unaligned pointer, for deallocation.  */
+};
+
+/* Type for the dtv.  */
+typedef union dtv
+{
+  size_t counter;
+  struct dtv_pointer pointer;
+} dtv_t;
+
+typedef struct
+{
+  void *tcb;		/* Pointer to the TCB.  Not necessarily the
+			   thread descriptor used by libpthread.  */
+  dtv_t *dtv;
+  void *self;		/* Pointer to the thread descriptor.  */
+  int multiple_threads;
+  int gscope_flag;
+  uintptr_t sysinfo;
+  uintptr_t stack_guard;
+  uintptr_t pointer_guard;
+  unsigned long int vgetcpu_cache[2];
+  int __glibc_reserved1;
+  int __glibc_unused1;
+  /* Reservation of some values for the TM ABI.  */
+  void *__private_tm[4];
+  /* GCC split stack support.  */
+  void *__private_ss;
+  long int __glibc_reserved2;
+  /* Must be kept even if it is no longer used by glibc since programs,
+     like AddressSanitizer, depend on the size of tcbhead_t.  */
+  //__128bits __glibc_unused2[8][4] __attribute__ ((aligned (32)));
+
+  //void *__padding[8];
+} tcbhead_t;
+
+static inline void *BaseAddr(void *addr, size_t align) {
+  return (void *)((uintptr_t)addr & PAGE_SIZE_4KB_ALIGN);
+}
+
+static void SegvfaultHandler(int signum, siginfo_t *siginfo, void *context) {
+  changed_tls_tcb.push_back(siginfo->si_addr);
+  /* TODO fulfill the request and continue */
+}
+
+static void AddSegvHandler() {
+  struct sigaction act = {0}, old_act;
+  act.sa_sigaction = &SegvfaultHandler;
+  act.sa_flags = SA_RESTART | SA_SIGINFO;
+  sigemptyset(&act.sa_mask);
+  if (sigaction(SIGSEGV, &act, &old_act)) {
+    printf("Failed to install segv handler\n");
+  }
+}
+
+static inline void JUMP_TO_LOWER_HALF(void *lhFs) {
+  // Compute the upper-half and lower-half fs addresses
+  if (!fsaddr_initialized) {
+    fsaddr_initialized = 1;
+    lh_fsaddr = lh_info.fsaddr - LH_TLS_SIZE;
+    uh_fsaddr_tcb = (void *)pthread_self();
+    uh_fsaddr = (char*)uh_fsaddr_tcb - LH_TLS_SIZE;
+
+    /* TODO:
+     * AddSegvHandler()
+     */
+
+    printf("%d %d %p %p %p %lx\n", __LINE__, getpid(), lh_fsaddr, lh_info.fsaddr, uh_fsaddr, pthread_self());
+    fflush(stdout);
+tcbhead_t *uhhead = (tcbhead_t *)(uh_fsaddr + LH_TLS_SIZE);
+tcbhead_t *lhhead = (tcbhead_t *)(lh_fsaddr + LH_TLS_SIZE);
+    printf("%d %d %p %p %p %d %x %lx %lx %lx %lu %lu %d %d %p %p %p %p %p\n", __LINE__, getpid(),
+lhhead->tcb, lhhead->dtv, lhhead->self, lhhead->multiple_threads, lhhead->gscope_flag, lhhead->sysinfo, lhhead->stack_guard, lhhead->pointer_guard, lhhead->vgetcpu_cache[0], lhhead->vgetcpu_cache[1],
+lhhead->__glibc_reserved1, lhhead->__glibc_unused1, lhhead->__private_tm[0], lhhead->__private_tm[1], lhhead->__private_tm[2], lhhead->__private_tm[3], lhhead->__private_ss);
+		  fflush(stdout);
+    printf("%d %d %p %p %p %d %x %lx %lx %lx %lu %lu %d %d %p %p %p %p %p\n", __LINE__, getpid(),
+uhhead->tcb, uhhead->dtv, uhhead->self, uhhead->multiple_threads, uhhead->gscope_flag, uhhead->sysinfo, uhhead->stack_guard, uhhead->pointer_guard, uhhead->vgetcpu_cache[0], uhhead->vgetcpu_cache[1],
+uhhead->__glibc_reserved1, uhhead->__glibc_unused1, uhhead->__private_tm[0], uhhead->__private_tm[1], uhhead->__private_tm[2], uhhead->__private_tm[3], uhhead->__private_ss);
+		  fflush(stdout);
+  }
+  memcpy(fsaddr_buf, uh_fsaddr, LH_TLS_SIZE + TCB_HEADER_SIZE);
+  memcpy(uh_fsaddr, lh_fsaddr, LH_TLS_SIZE + TCB_HEADER_SIZE);
+
+  // on x86_64:
+  // the tcb starts with 3 ptrs: self, dtv, header
+  // self is used to get TLS variables
+  // dtv is used to load tls for dynamically loaded libraries
+  // header is used to access the tcb
+  // self, header, and fs reg all point to the start of the tcb
+
+  // we change the self pointed to point to the tcb at the new location
+  // we leave the header pointer intact so that the tcb is modified in-place
+  // at the old location
+
+  // changing the location breaks things that keep pointers into the struct,
+  // like linked lists. TCB has a lot of internal self-pointers and lists, so
+  // it is advantageous to keep it in place. TLS usually has less (application
+  // dependent), and must be moved because it can be accessed relative to fs
+  // with no indirection. So we change self but not header.
+
+  // change self pointer to new application half TLS location
+  ((void **)(uh_fsaddr + LH_TLS_SIZE))[0] = (void *) (uh_fsaddr + LH_TLS_SIZE);
+  ((void **)(uh_fsaddr + LH_TLS_SIZE))[2] = (void *) (uh_fsaddr + LH_TLS_SIZE);
+
+  /* Set uh tls&tcb to read only */
+  if (mprotect(BaseAddr(uh_fsaddr_tcb, PAGE_SIZE_4KB_ALIGN), (size_t)((uintptr_t)uh_fsaddr_tcb & (PAGE_SIZE_4KB - 1))  + PTHREAD_SIZE, PROT_READ)) {
+    printf("%s %d %m\n", __func__, __LINE__);
+    fflush(stdout);
+  }
+
+}
+
+static inline void RETURN_TO_UPPER_HALF(const char* func) {
+	bool changed = false;
+tcbhead_t *uhhead = (tcbhead_t *)(uh_fsaddr + LH_TLS_SIZE);
+tcbhead_t *lhhead = (tcbhead_t *)(lh_fsaddr + LH_TLS_SIZE);
+  if (uhhead->dtv != lhhead->dtv
+      || uhhead->multiple_threads != lhhead->multiple_threads
+      || uhhead->gscope_flag != lhhead->gscope_flag
+      || uhhead->sysinfo != lhhead->sysinfo
+      || uhhead->stack_guard != lhhead->stack_guard
+      || uhhead->pointer_guard != lhhead->pointer_guard
+      || uhhead->vgetcpu_cache[0] != lhhead->vgetcpu_cache[0]
+      || uhhead->vgetcpu_cache[1] != lhhead->vgetcpu_cache[1]
+      || uhhead->__glibc_reserved1 != lhhead->__glibc_reserved1
+      || uhhead->__glibc_unused1 != lhhead->__glibc_unused1
+      || uhhead->__private_tm[0] != lhhead->__private_tm[0]
+      || uhhead->__private_tm[1] != lhhead->__private_tm[1]
+      || uhhead->__private_tm[2] != lhhead->__private_tm[2]
+      || uhhead->__private_tm[3] != lhhead->__private_tm[3]
+      || uhhead->__private_ss != lhhead->__private_ss
+      ) {
+	  changed = true;
+          memcpy(debug_buf, lh_fsaddr, LH_TLS_SIZE + TCB_HEADER_SIZE);
+  }
+
+  /* Set uh tls&tcb back to RW */
+  if (mprotect(BaseAddr(uh_fsaddr_tcb, PAGE_SIZE_4KB_ALIGN), (size_t)((uintptr_t)uh_fsaddr_tcb & (PAGE_SIZE_4KB - 1)) + PTHREAD_SIZE, PROT_READ | PROT_WRITE)) {
+    printf("%s %d %m\n", __func__, __LINE__);
+    fflush(stdout);
+  }
+
+  memcpy(lh_fsaddr, uh_fsaddr, LH_TLS_SIZE + TCB_HEADER_SIZE);
+  memcpy(uh_fsaddr, fsaddr_buf, LH_TLS_SIZE + TCB_HEADER_SIZE);
+
+  // restore self pointer to original driver-half TLS location
+  // Only copy TLS back to driver half
+  ((void **)(lh_fsaddr + LH_TLS_SIZE))[0] = (void *) (lh_fsaddr + LH_TLS_SIZE);
+  ((void **)(lh_fsaddr + LH_TLS_SIZE))[2] = (void *) (lh_fsaddr + LH_TLS_SIZE);
+
+  // Can only call printf in uh
+  if (changed) {
+//    JTRACE("changed ls_fsaddr uh_fsaddr") (lh_fsaddr) (uh_fsaddr);
+//tcbhead_t *lhhead = (tcbhead_t *)(lh_fsaddr + LH_TLS_SIZE);
+tcbhead_t *debughead = (tcbhead_t *)(debug_buf + LH_TLS_SIZE);
+    printf("%d %d API %s changed ls_fsaddr %p uh_fsaddr %p %p %p %s %d\n", __LINE__, getpid(), func, lh_fsaddr, uh_fsaddr, lhhead, uhhead, __func__, __LINE__);
+		  fflush(stdout);
+    printf("%d %d %p %p %p %d %x %lx %lx %lx %lu %lu %d %d %p %p %p %p %p\n", __LINE__, getpid(),
+lhhead->tcb, lhhead->dtv, lhhead->self, lhhead->multiple_threads, lhhead->gscope_flag, lhhead->sysinfo, lhhead->stack_guard, lhhead->pointer_guard, lhhead->vgetcpu_cache[0], lhhead->vgetcpu_cache[1],
+lhhead->__glibc_reserved1, lhhead->__glibc_unused1, lhhead->__private_tm[0], lhhead->__private_tm[1], lhhead->__private_tm[2], lhhead->__private_tm[3], lhhead->__private_ss);
+		  fflush(stdout);
+    printf("%d %d %p %p %p %d %x %lx %lx %lx %lu %lu %d %d %p %p %p %p %p\n", __LINE__, getpid(),
+debughead->tcb, debughead->dtv, debughead->self, debughead->multiple_threads, debughead->gscope_flag, debughead->sysinfo, debughead->stack_guard, debughead->pointer_guard, debughead->vgetcpu_cache[0], debughead->vgetcpu_cache[1],
+debughead->__glibc_reserved1, debughead->__glibc_unused1, debughead->__private_tm[0], debughead->__private_tm[1], debughead->__private_tm[2], debughead->__private_tm[3], debughead->__private_ss);
+		  fflush(stdout);
+
+  }
+}
+#endif
+
+// ===================================================
 // This function splits the process by initializing the lower half with the
 // lh_proxy code. It returns 0 on success.
 extern int splitProcess();

--- a/contrib/mpi-proxy-split/test/Makefile
+++ b/contrib/mpi-proxy-split/test/Makefile
@@ -26,7 +26,8 @@ FILES=mpi_hello_world \
       Ibcast_test Ibarrier_test Isend_test \
       Abort_test Allreduce_test Alltoall_test Alltoallv_test \
       Allgather_test Group_size_rank Type_commit_contiguous \
-      Irecv_test Alloc_mem
+      Irecv_test Alloc_mem \
+      f_ibarrier
 
 OBJS=$(addsuffix .o, ${FILES})
 
@@ -132,6 +133,12 @@ check-integrated_dmtcp_text: tidy integrated_dmtcp_test
 
 %.o: %.c
 	 $(MPICC) -g3 -O0 -c -o $@ $< $(MPI_CFLAGS)
+
+%.exe: %.f90
+	ftn -g3 -O0 -o $@ $< -fPIC
+
+%.mana.exe: %.f90
+	ftn -g3 -O0 -o $@ $< -fPIC ${LDFLAGS_DUMMY}
 
 %.exe: %.o
 	 $(MPICC) -o $@ $< ${MPI_LDFLAGS}

--- a/contrib/mpi-proxy-split/test/f_ibarrier.f90
+++ b/contrib/mpi-proxy-split/test/f_ibarrier.f90
@@ -1,0 +1,20 @@
+PROGRAM hello_world_mpi
+include 'mpif.h'
+
+integer process_Rank, size_Of_Cluster, ierror, tag, flag
+integer request, status(MPI_STATUS_SIZE)
+logical dummy
+
+call MPI_INIT(ierror)
+call MPI_COMM_SIZE(MPI_COMM_WORLD, size_Of_Cluster, ierror)
+call MPI_COMM_RANK(MPI_COMM_WORLD, process_Rank, ierror)
+call MPI_IBARRIER(MPI_COMM_WORLD, request, ierror)
+dummy = .true.
+do while (dummy)
+end do
+call MPI_Wait(request, status, ierror)
+
+print *, 'Hello World from process: ', process_Rank, 'of ', size_Of_Cluster
+
+call MPI_FINALIZE(ierror)
+END PROGRAM

--- a/contrib/mpi-proxy-split/two-phase-algo.cpp
+++ b/contrib/mpi-proxy-split/two-phase-algo.cpp
@@ -95,11 +95,11 @@ int
 TwoPhaseAlgo::commit(MPI_Comm comm, const char *collectiveFnc,
                      std::function<int(void)>doRealCollectiveComm)
 {
-  if (!LOGGING() || comm == MPI_COMM_NULL) {
+  if (!LOGGING_MPI() || comm == MPI_COMM_NULL) {
     return doRealCollectiveComm(); // lambda function: already captured args
   }
 
-  if (!LOGGING()) {
+  if (!LOGGING_MPI()) {
     return doRealCollectiveComm();
   }
 
@@ -134,7 +134,7 @@ TwoPhaseAlgo::commit_begin(MPI_Comm comm)
   int tb_rc = -1;
   JUMP_TO_LOWER_HALF(lh_info.fsaddr);
   tb_rc = NEXT_FUNC(Ibarrier)(realComm, &request);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   MPI_Request virtRequest = ADD_NEW_REQUEST(request);
   _request = virtRequest;
   JASSERT(tb_rc == MPI_SUCCESS)
@@ -202,7 +202,7 @@ TwoPhaseAlgo::replayTrivialBarrier()
     int tb_rc = -1;
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     tb_rc = NEXT_FUNC(Ibarrier)(realComm, &request);
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
     UPDATE_REQUEST_MAP(_request, request);
     _replayTrivialBarrier = false;
   }

--- a/contrib/mpi-proxy-split/virtual-ids.h
+++ b/contrib/mpi-proxy-split/virtual-ids.h
@@ -303,7 +303,7 @@ namespace dmtcp_mpi
         JUMP_TO_LOWER_HALF(lh_info.fsaddr);
         NEXT_FUNC(Allgather)(&worldRank, 1, MPI_INT,
                              rbuf, 1, MPI_INT, realComm);
-        RETURN_TO_UPPER_HALF();
+        RETURN_TO_UPPER_HALF(__func__);
         DMTCP_PLUGIN_ENABLE_CKPT();
 #else
         MPI_Allgather(&worldRank, 1, MPI_INT, rbuf, 1, MPI_INT, comm);

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -742,7 +742,7 @@ main(int argc, char *argv[], char **environ)
     JUMP_TO_LOWER_HALF(lh_info.fsaddr);
     // MPI_Init is called here. GNI memory areas will be loaded by MPI_Init.
     rank = ((getRankFptr_t)lh_info.getRankFptr)();
-    RETURN_TO_UPPER_HALF();
+    RETURN_TO_UPPER_HALF(__func__);
 
     afterLoadingGniDriverUnblockAddressRanges(start1, end1, start2, end2);
     unreserve_fds_upper_half(reserved_fds,total_reserved_fds);

--- a/src/mtcp/mtcp_split_process.c
+++ b/src/mtcp/mtcp_split_process.c
@@ -318,6 +318,6 @@ initializeLowerHalf()
   }
   DPRINTF("After getcontext");
   patchAuxv(auxvec, 0, 0, 0);
-  RETURN_TO_UPPER_HALF();
+  RETURN_TO_UPPER_HALF(__func__);
   return ret;
 }

--- a/src/mtcp/mtcp_split_process.h
+++ b/src/mtcp/mtcp_split_process.h
@@ -66,7 +66,7 @@ extern LowerHalfInfo_t lh_info;
 
 // Helper macro to be used whenever making a returning from the lower half to
 // the upper half.
-#define RETURN_TO_UPPER_HALF()                                                 \
+#define RETURN_TO_UPPER_HALF(__func__)                                                 \
   mtcp_inline_syscall(arch_prctl, 2, ARCH_SET_FS, &upperHalfFs);               \
   } while (0)
 


### PR DESCRIPTION
Replace minimal TLS/TCB header
Don't copy back TCB when jump back, add comments
Use SET_LOWER_HALF_FS_CONTEXT in all wrappers
WIP: Add fortran MPI_Ibarrier test case
WIP: debug TLS/TCB
Increase TLS size to 0x4a0
Tmp changes
Make it can enable LOGGING
C/R crash debug
Track TLS/TCB changes